### PR TITLE
Changed keylistener to keydown

### DIFF
--- a/src/components/Board.vue
+++ b/src/components/Board.vue
@@ -51,7 +51,7 @@
             };
         },
         created() {
-            window.addEventListener("keyup", this.listenKeysPressed);
+            window.addEventListener("keydown", this.listenKeysPressed);
             this.audioMap = {
                 gameStart: new Audio('sounds/game_start.wav'),
                 gameOver: new Audio('sounds/game_over.wav'),


### PR DESCRIPTION
When playing it felt a bit laggy by having it listen to keyup events as it wouldn't change direction immediately, especially if I accidentally kept the key held down. It may just be personal preference so feel free to accept or deny this change :). 