### PR TITLE
Add safeguard to prevent new square randomly poping up outside the board

### DIFF
--- a/src/components/Board.vue
+++ b/src/components/Board.vue
@@ -174,11 +174,11 @@
             },
             getFoodRandomCoords() {
                 let randomCoords = [
-                    Math.floor(Math.random() * (this.width - 1)),
-                    Math.floor(Math.random() * (this.height - 1))
+                    Math.floor(Math.random() * this.width),
+                    Math.floor(Math.random() * this.height)
                 ].join(",");
 
-                if (this.squares[randomCoords] !== SNAKE.NONE) {
+                if (this.squares[randomCoords] !== SNAKE.NONE || randomCoords.includes(this.width + ",") || randomCoords.includes("," + this.height)) {
                     return this.getFoodRandomCoords();
                 }
 

--- a/src/components/Board.vue
+++ b/src/components/Board.vue
@@ -213,14 +213,13 @@
                 let randomCoords = [
                     Math.floor(Math.random() * this.width),
                     Math.floor(Math.random() * this.height)
-                ].join(",");
+                ];
 
-                if (this.squares[randomCoords] !== SNAKE.NONE || randomCoords.includes(this.width + ",") || randomCoords.includes("," + this.height)) {
+                if (this.squares[randomCoords.toString()] !== SNAKE.NONE || randomCoords[0] === this.width || randomCoords[1] === this.height) {
                     return this.getFoodRandomCoords();
                 }
 
-                return randomCoords;
-
+                return randomCoords.toString();
             },
             increaseSpeed() {
                 if (this.speed <= 90) {


### PR DESCRIPTION
As we know Math.random() function returns a floating-point, pseudo-random number in the range 0–1 (inclusive of 0, but not 1), So it's not going to return 1 but it may return something like 0.99999999999999999 (probability is very very less though) which in turns Math.Floor(0.99999999999999999 * 20) => Math.Floor(20) and here Math.Floor doesn't help. Anyway to avoid the edge case (it might be), added safeguard in the code to prevent the randomCoords move out of the board grid.

Fixes #2